### PR TITLE
Q 4 ) The description cannot be null is the stage is closedwon in opp…

### DIFF
--- a/force-app/main/default/classes/OpportunityTriggerHandler.cls
+++ b/force-app/main/default/classes/OpportunityTriggerHandler.cls
@@ -1,0 +1,10 @@
+public with sharing class OpportunityTriggerHandler {
+    //update for the review.
+    public static void checkDescriptionForClosedWon(List<Opportunity> newOpportunities) {
+        for(Opportunity opp: newOpportunities){
+            if(opp.StageName == 'Closed Won' && opp.Description == null){
+                opp.addError('Description is required for closed won opportunities');
+            }
+        }
+    }
+}

--- a/force-app/main/default/classes/OpportunityTriggerHandler.cls-meta.xml
+++ b/force-app/main/default/classes/OpportunityTriggerHandler.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>64.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/triggers/OpportunityTrigger.trigger
+++ b/force-app/main/default/triggers/OpportunityTrigger.trigger
@@ -1,0 +1,8 @@
+trigger OpportunityTrigger on Opportunity (before insert, before update, after insert, after update) {
+    //Update for the review.
+    if(Trigger.isBefore) {
+        if(Trigger.isInsert || Trigger.isUpdate) {
+        	OpportunityTriggerHandler.checkDescriptionForClosedWon(Trigger.new);
+    	}
+    }
+}

--- a/force-app/main/default/triggers/OpportunityTrigger.trigger-meta.xml
+++ b/force-app/main/default/triggers/OpportunityTrigger.trigger-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>64.0</apiVersion>
+  <status>Active</status>
+</ApexTrigger>


### PR DESCRIPTION
### Problem Statement: 
 
Q 4) Write a trigger on Opportunity, to validate the data and shows the error on field. If  the ‘StageName’ is ‘Closed Won’ and the ‘Description’ is Null or Empty, add an error  on the field of that record with meaningful error message.